### PR TITLE
[+] Add maximum projects returned in user api

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: bundle exec rake db:migrate
+web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,7 +126,7 @@ class User < ApplicationRecord
     tree
   end
 
-  def get_n_latest_unique_viewed(item_type = 'Project', n = 10)
+  def get_n_latest_unique_viewed(item_type = 'Project', n = 16)
     given_views.where(viewable_type: 'Project').order('created_at DESC').map { |v| v.viewable_id }.uniq[0..(n - 1)]
   end
 end

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -9,10 +9,10 @@ end
 
 json.skills user.skills.map { |s| s.name }
 
-json.joined_projects user.projects.order('created_at DESC').map { |p| p.id }
+json.joined_projects user.projects.order('created_at DESC').map { |p| p.id }[0..2]
 
-json.starred_projects user.favorites.order('created_at DESC').map { |f| f.project_id }
+json.starred_projects user.favorites.order('created_at DESC').map { |f| f.project_id }[0..8]
 
-json.followed_projects user.given_follows.where(followable_type: 'Project').order('created_at DESC').map { |gf| gf.followable_id }
+json.followed_projects user.given_follows.where(followable_type: 'Project').order('created_at DESC').map { |gf| gf.followable_id }[0..8]
 
-json.viewed_projects user.get_n_latest_unique_viewed
+json.viewed_projects user.get_n_latest_unique_viewed(16)


### PR DESCRIPTION
# Overview

- Add maximum projects returned in user API
  - joined_projects = 3 recent
  - starred_projects = 8 recent
  - followed_projects = 8 recent
  - viewed_projects = 16 recent
- Add auto migrate when deploy to Heroku