### PR TITLE
[~] Hotfix - Change MembersController to RolesController

### DIFF
--- a/app/controllers/projects/roles_controller.rb
+++ b/app/controllers/projects/roles_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class Projects::MembersController < ApplicationController
+class Projects::RolesController < ApplicationController
   def show; end
 end


### PR DESCRIPTION
# Overview
- Rename `MembersController` to `RolesController` in `projects/roles_controller.rb`